### PR TITLE
fix empty submenu bug

### DIFF
--- a/xdg-dmenu.sh
+++ b/xdg-dmenu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Author: @fallc0nn (github, twitter)
-# Last Update: 20-May-2016
-# Tested with Kali 2016.1 (Rolling Release), file "/etc/xdg/menus/applications-merged/kali-applications.menu"
+# Last Update: 23-Nov-2020
+# Tested with Kali 2020.4 (Rolling Release), file "/etc/xdg/menus/applications-merged/kali-applications.menu"
 
 dmenu_cmd="dmenu -i -l 25 -fn -xos4-terminus-medium-r-*-*-14-*"
 menu_path="/etc/xdg/menus/applications-merged/kali-applications.menu"
@@ -16,11 +16,12 @@ menu_selected="$(grep "<Name>" "$menu_path" |grep -v "$(for e in $(echo $menu_ex
 
 ## (2) Submenu list and it's tools:
 menu_dir="$(grep -A1 "${menu_selected:${#menu_prefix}+1}" "$menu_path" |tail -1 |grep -Eo ">[^\.]+" |tr -d ">")"
-submenu_selected="$({ grep "<Name>" "$menu_path" |grep -v "$(for e in $(echo $menu_exceptions |tr "," "\n"); do echo "Name>$e\|";done |sed "s/\\\|$//")" |sed "s/<\/\?Name>//g;s/^\ \{4\}/$menu_prefix /" |sed -n "/${menu_selected:${#menu_prefix}+1}/,/^$menu_prefix\ [^\ ]/p" |head -n -1 |tail -n +2 |sed "s/$menu_prefix \+/$menu_selected > /" |sort; for tool in $(grep -ir "Categories=.*$menu_dir" "$apps_path" |cut -d":" -f1); do grep "Name=" "$tool" |cut -d"=" -f2 ;done |sort; } |$dmenu_cmd |grep -Eo "> [^>]+$")"
+submenu_selected="$({ grep "<Name>" "$menu_path" |grep -v "$(for e in $(echo $menu_exceptions |tr "," "\n"); do echo "Name>$e\|";done |sed "s/\\\|$//")" |sed "s/<\/\?Name>//g;s/^\ \{4\}/$menu_prefix /" |sed -n "/${menu_selected:${#menu_prefix}+1}/,/^$menu_prefix\ [^\ ]/p" |head -n -1 |tail -n +2 |sed "s/$menu_prefix \+/$menu_selected > /" |sort; for tool in $(grep -ir "Categories=.*$menu_dir" "$apps_path" |cut -d":" -f1); do grep "Name=" "$tool" |cut -d"=" -f2 ;done |sort; } |$dmenu_cmd)"
 [[ ! "$submenu_selected" ]] && exit 1
 
 ## (3) If submenu, list it's tools. Else, execute tool:
-[[ "${submenu_selected:0:1}" == ">" ]] && {
+[[ "$submenu_selected" =~ " > " ]] && {
+    submenu_selected=$( awk -F " > " '{print $2}' <<< "$submenu_selected")
     submenu_dir="$(grep -A1 "${submenu_selected:${#menu_prefix}+1}" "$menu_path" |tail -1 |grep -Eo ">[^\.]+" |tr -d ">")"
     toolexec="$(for tool in $(grep -ir "Categories=.*$submenu_dir" "$apps_path" |cut -d":" -f1); do grep "Name=" "$tool" |cut -d"=" -f2 ;done |sort |$dmenu_cmd)"
     [[ ! "$toolexec" ]] && exit 1 || $term_cmd "$(find "$apps_path" -iname "*$toolexec*.desktop" -exec grep "Exec" {} \; |cut -d"=" -f2)"


### PR DESCRIPTION
First of all thanks for this awesome script. It's a lifesaver for tiling window managers.

Currently the script doesn't work for items in `menu_selected` but only with the ones in sub-menus. 
The reason is grep in line 19: `|$dmenu_cmd |grep -Eo "> [^>]+$")"`
if the selected item is not a submenu, grep will return nothing because of `-o` parameter and the script will exit:  ```[[! "$submenu_selected" ]] && exit 1```
Just updated the sub-menu / tool detection statement to fix the problem.